### PR TITLE
Updating code to explicitly fail if skip greater than 10000

### DIFF
--- a/samples/asyncio_example.py
+++ b/samples/asyncio_example.py
@@ -7,7 +7,7 @@ import vulners
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 
-vulners_api = vulners.Vulners()
+vulners_api = vulners.Vulners(api_key="YOUR_API_KEY_HERE")
 
 loop = asyncio.get_event_loop()
 # pool = ProcessPoolExecutor(max_workers=multiprocessing.cpu_count())

--- a/samples/multi_test.py
+++ b/samples/multi_test.py
@@ -8,7 +8,7 @@
 import concurrent.futures
 import vulners
 
-vulners_api = vulners.Vulners()
+vulners_api = vulners.Vulners(api_key="YOUR_API_KEY_HERE")
 
 collection_names = vulners_api.collections()[:20]
 

--- a/samples/search.py
+++ b/samples/search.py
@@ -8,5 +8,6 @@ import vulners
 
 vulners_api = vulners.Vulners(api_key="YOUR_API_KEY_HERE")
 possible_autocomplete = vulners_api.autocomplete("heartbleed")
-heartbleed_related, total_heartbleed = vulners_api.search("heartbleed", limit=10)
+heartbleed_related = vulners_api.search("heartbleed", limit=10)
+total_heartbleed = heartbleed_related.total  # Notice you can do this because of Vulners' own AttributeList type
 CVE_2017_14174 = vulners_api.document("CVE-2017-14174")

--- a/samples/software_scanner.py
+++ b/samples/software_scanner.py
@@ -6,7 +6,7 @@
 
 import vulners
 
-vulners_api = vulners.Vulners()
+vulners_api = vulners.Vulners(api_key="YOUR_API_KEY_HERE")
 
 # Download web application vulnerability detection regex collection
 rules = vulners_api.rules()

--- a/vulners/api.py
+++ b/vulners/api.py
@@ -280,9 +280,9 @@ class Vulners(object):
         """
         if not isinstance(query, string_types):
             raise TypeError("Search query expected to be a string")
-        if not isinstance(skip, int) or not 0 <= skip <= 10000:
+        if not isinstance(skip, int) or not 0 <= skip <= 9999:
             raise TypeError(
-                "Skip expected to be an int in range 0-10000, Vulners "
+                "Skip expected to be an int in range 0-9999, Vulners "
                 "won't provide records if skip is greater than that.")
         if not isinstance(size, int) or not 0 <= size <= 100:
             raise TypeError(
@@ -419,7 +419,7 @@ class Vulners(object):
 
         :param query: Abstract Vulners query. See https://vulners.com/help for the details.
         :param limit: a.k.a. search size. Default is 100 records.
-        :param offset: Skip this amount of documents. 10000 is Vulners' absolute maximum.
+        :param offset: Skip this amount of documents. 9999 is Vulners' absolute maximum.
         :param fields: Returnable fields of the data model.
         :return: AttributeList of the found documents. Total number of found bulletins can be retrieved on r.total
         """
@@ -440,7 +440,7 @@ class Vulners(object):
 
         :param query: Abstract Vulners query. See https://vulners.com/help for the details.
         :param pageSize: Search size. Default is 20 in the single hit. 100 is the maximum
-        :param offset: Skip this amount of documents. 10000 is the hard limit
+        :param offset: Skip this amount of documents. 9999 is the hard limit
         :param fields: Returnable fields of the data model.
         :return: List of the found documents, total found bulletins
         """
@@ -461,7 +461,7 @@ class Vulners(object):
         :param query: Print here software name and criteria
         :param lookup_fields: Make a strict search using lookup limit. Like ["title"]
         :param limit: Search size. Default is 500 elements limit. 10000 is absolute maximum.
-        :param offset: Skip this amount of documents. 10000 is absolute maximum.
+        :param offset: Skip this amount of documents. 9999 is absolute maximum.
         :param fields: Returnable fields of the data model.
         :return: List of the found documents, total found bulletins
         """


### PR DESCRIPTION
First: Just updating the samples codebase 
Second: Allowing the API to explicitly fail when trying to skip more than 10000 records in the request to Vulners instead of silently failing with no retrieved records. This lets the user know that something is going wrong with the request and that the API was unable to retrieve the entire list of records as it was supposed to.
Note: IMHO, these [conditions](https://github.com/vulnersCom/api/compare/master...jsvasquez:master#diff-a01831bb2020f6760819e9bad7d94f130a1a96661e8047543358cb3cce2a1501L282-L285) were failing, please correct if I'm wrong.

Totally open to suggestions and/or edits.

Thank you.