### PR TITLE
fix: name the proxy on connection failures and stop retrying 407

### DIFF
--- a/documentation/how-to/proxy-timeout-retries.md
+++ b/documentation/how-to/proxy-timeout-retries.md
@@ -116,6 +116,15 @@ export NO_PROXY="localhost,127.0.0.1,.internal.example"
 
 Pass an explicit `proxy=` to override them, or `trust_env=False` to ignore the environment.
 
+### When the proxy is the problem
+
+If a request cannot reach the API *through* the proxy, the `APIConnectionError` names the
+proxy hop (with any credentials stripped) — e.g. `Connection error: [Errno 111] Connection
+refused (proxy http://proxy.corp.example:8080)` — so a misconfigured or unreachable proxy is
+not mistaken for the API being down. A `407 Proxy Authentication Required` is treated as a
+terminal error and raised immediately: the same credentials would be rejected on every retry,
+so it is **not** subject to `max_retries`.
+
 ### A proxy together with custom TLS or transport
 
 For a proxy *plus* custom TLS, HTTP/2 tuning or a mounted transport, build your own `httpx`

--- a/src/vulners/_base_client.py
+++ b/src/vulners/_base_client.py
@@ -94,6 +94,28 @@ def _mount_guard(client: Any, transport_cls: Any, origin: httpx.URL) -> None:
     }
 
 
+def _redact_proxy(proxy: str | httpx.Proxy) -> str:
+    """A credential-free ``scheme://host[:port]`` rendering of a proxy.
+
+    Safe to put in an error message or log: any userinfo (a proxy password) is
+    dropped, so naming the proxy that failed can never leak its credentials.
+    """
+    url = proxy.url if isinstance(proxy, httpx.Proxy) else httpx.URL(proxy)
+    netloc = url.host if url.port is None else f"{url.host}:{url.port}"
+    return f"{url.scheme}://{netloc}"
+
+
+def _is_proxy_auth_error(exc: BaseException) -> bool:
+    """True for a ``407 Proxy Authentication Required`` from the configured proxy.
+
+    httpx surfaces the proxy's CONNECT status only in the ``ProxyError`` message
+    (there is no numeric status attribute), so the 407 is matched on that text.
+    The failure is terminal — the same credentials are rejected on every attempt
+    — so the retry loop must treat it as non-retryable rather than repeating it.
+    """
+    return isinstance(exc, httpx.ProxyError) and str(exc).lstrip().startswith("407")
+
+
 def _json_loads_lenient(data: bytes | bytearray | str) -> Any:
     """Decode JSON with orjson, falling back to the stdlib decoder on its edges.
 
@@ -131,10 +153,27 @@ class BaseClient:
 
     def __init__(self, config: ClientConfig) -> None:
         self._config = config
+        # The proxy the SDK-owned transport actually uses (explicit ``proxy=`` or
+        # the one resolved from the environment); ``None`` for a bring-your-own
+        # client. Set by the I/O subclasses and used only to name the proxy in a
+        # connection-error message.
+        self._proxy: str | httpx.Proxy | None = None
 
     @property
     def config(self) -> ClientConfig:
         return self._config
+
+    def _connection_error_message(self, exc: Exception) -> str:
+        """``Connection error: ...``, naming the proxy when one is configured.
+
+        A failure to reach the API *through a proxy* otherwise surfaces as a bare
+        ``Connection refused`` / ``407 ...`` that gives no hint the proxy — not
+        the API host — is the unreachable/rejecting hop.
+        """
+        message = f"Connection error: {exc}"
+        if self._proxy is not None:
+            message = f"{message} (proxy {_redact_proxy(self._proxy)})"
+        return message
 
     # -- request building --------------------------------------------------
 
@@ -242,6 +281,10 @@ class BaseClient:
         return spec.ratelimit_group or spec.path
 
     def _retryable_exc(self, exc: Exception, spec: RequestSpec) -> bool:
+        # A 407 from the proxy is terminal (the credentials will not change
+        # between attempts), so it is never retried — even on an idempotent verb.
+        if _is_proxy_auth_error(exc):
+            return False
         # Connection-establishment failures never delivered the request, so they
         # are always safe to retry; read/write failures only on idempotent verbs.
         if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout)):

--- a/src/vulners/_transport_client_async.py
+++ b/src/vulners/_transport_client_async.py
@@ -67,6 +67,10 @@ class AsyncAPIClient(BaseClient):
             # proxy/verify/trust_env ride on the inner transport: httpx ignores
             # client-level verify once an explicit transport is passed, and a
             # client-level proxy would mount an unguarded transport over ours.
+            # Explicit proxy=, else the env proxy for base_url when trust_env
+            # (the explicit transport bypasses httpx's client-level env mounts).
+            # Kept on the client so a connection failure can name the proxy hop.
+            self._proxy = resolve_proxy(config)
             transport = AsyncVulnersTransport(
                 httpx.AsyncHTTPTransport(
                     # retries=0: the SDK request loop is the single retry owner
@@ -75,9 +79,7 @@ class AsyncAPIClient(BaseClient):
                     # would multiply attempts (up to connect_retries x max_retries).
                     retries=0,
                     http2=config.http2,
-                    # Explicit proxy=, else the env proxy for base_url when trust_env
-                    # (the explicit transport bypasses httpx's client-level env mounts).
-                    proxy=resolve_proxy(config),
+                    proxy=self._proxy,
                     verify=config.verify,
                     trust_env=config.trust_env,
                 ),
@@ -147,7 +149,7 @@ class AsyncAPIClient(BaseClient):
                 await self._emit_error(error)
                 raise error from exc
             except httpx.TransportError as exc:
-                error = APIConnectionError(f"Connection error: {exc}")
+                error = APIConnectionError(self._connection_error_message(exc))
                 if attempt < retries and self._retryable_exc(exc, spec):
                     attempt += 1
                     await self._sleep(_retry_timeout(attempt))
@@ -252,7 +254,7 @@ class AsyncAPIClient(BaseClient):
                 await self._emit_error(error)
                 raise error from exc
             except httpx.TransportError as exc:
-                error = APIConnectionError(f"Connection error: {exc}")
+                error = APIConnectionError(self._connection_error_message(exc))
                 if attempt < retries and self._retryable_exc(exc, spec):
                     attempt += 1
                     await self._sleep(_retry_timeout(attempt))

--- a/src/vulners/_transport_client_sync.py
+++ b/src/vulners/_transport_client_sync.py
@@ -72,6 +72,10 @@ class SyncAPIClient(BaseClient):
             # proxy/verify/trust_env ride on the inner transport: httpx ignores
             # client-level verify once an explicit transport is passed, and a
             # client-level proxy would mount an unguarded transport over ours.
+            # Explicit proxy=, else the env proxy for base_url when trust_env
+            # (the explicit transport bypasses httpx's client-level env mounts).
+            # Kept on the client so a connection failure can name the proxy hop.
+            self._proxy = resolve_proxy(config)
             transport = VulnersTransport(
                 httpx.HTTPTransport(
                     # retries=0: the SDK request loop is the single retry owner
@@ -80,9 +84,7 @@ class SyncAPIClient(BaseClient):
                     # would multiply attempts (up to connect_retries x max_retries).
                     retries=0,
                     http2=config.http2,
-                    # Explicit proxy=, else the env proxy for base_url when trust_env
-                    # (the explicit transport bypasses httpx's client-level env mounts).
-                    proxy=resolve_proxy(config),
+                    proxy=self._proxy,
                     verify=config.verify,
                     trust_env=config.trust_env,
                 ),
@@ -150,7 +152,7 @@ class SyncAPIClient(BaseClient):
                 self._emit_error(error)
                 raise error from exc
             except httpx.TransportError as exc:
-                error = APIConnectionError(f"Connection error: {exc}")
+                error = APIConnectionError(self._connection_error_message(exc))
                 if attempt < retries and self._retryable_exc(exc, spec):
                     attempt += 1
                     self._sleep(_retry_timeout(attempt))
@@ -255,7 +257,7 @@ class SyncAPIClient(BaseClient):
                 self._emit_error(error)
                 raise error from exc
             except httpx.TransportError as exc:
-                error = APIConnectionError(f"Connection error: {exc}")
+                error = APIConnectionError(self._connection_error_message(exc))
                 if attempt < retries and self._retryable_exc(exc, spec):
                     attempt += 1
                     self._sleep(_retry_timeout(attempt))

--- a/tests/core/test_base_client_units.py
+++ b/tests/core/test_base_client_units.py
@@ -15,7 +15,13 @@ import httpx
 import orjson
 import pytest
 
-from vulners._base_client import BaseClient, RequestSpec, _clean_params
+from vulners._base_client import (
+    BaseClient,
+    RequestSpec,
+    _clean_params,
+    _is_proxy_auth_error,
+    _redact_proxy,
+)
 from vulners._config import (
     ARCHIVE_TIMEOUT,
     DEFAULT_TIMEOUT,
@@ -294,6 +300,54 @@ class TestBucketHeaderUpdate:
         resp = httpx.Response(200, headers={"X-Vulners-Ratelimit-Reqlimit": "0.5"})
         c._update_bucket_from_headers(bucket, resp)  # 0.5/60 < 1/60 -> ignored
         assert bucket._rate == 10.0
+
+
+class TestRedactProxy:
+    def test_str_proxy_with_port(self):
+        assert _redact_proxy("http://proxy.local:3128") == "http://proxy.local:3128"
+
+    def test_str_proxy_without_port(self):
+        # No explicit port -> host only, no trailing colon.
+        assert _redact_proxy("http://proxy.local") == "http://proxy.local"
+
+    def test_credentials_are_stripped(self):
+        # A proxy password must never reach a message/log via the redacted form.
+        redacted = _redact_proxy("http://user:secret@proxy.local:3128")
+        assert redacted == "http://proxy.local:3128"
+        assert "user" not in redacted
+        assert "secret" not in redacted
+
+    def test_httpx_proxy_instance(self):
+        proxy = httpx.Proxy("http://user:secret@proxy.local:8080")
+        assert _redact_proxy(proxy) == "http://proxy.local:8080"
+
+
+class TestIsProxyAuthError:
+    def test_407_proxy_error_is_terminal(self):
+        assert _is_proxy_auth_error(httpx.ProxyError("407 Proxy Authentication Required"))
+
+    def test_non_407_proxy_error_is_not(self):
+        # A 502 from the proxy is not the terminal auth case; still retryable.
+        assert not _is_proxy_auth_error(httpx.ProxyError("502 Bad Gateway"))
+
+    def test_non_proxy_error_is_not(self):
+        assert not _is_proxy_auth_error(httpx.ConnectError("refused"))
+
+
+class TestConnectionErrorMessage:
+    def test_names_proxy_when_configured(self):
+        c = _client()
+        c._proxy = "http://user:secret@proxy.local:3128"
+        message = c._connection_error_message(httpx.ConnectError("refused"))
+        assert message == "Connection error: refused (proxy http://proxy.local:3128)"
+        assert "secret" not in message
+
+    def test_plain_when_no_proxy(self):
+        c = _client()
+        assert c._proxy is None
+        assert c._connection_error_message(httpx.ConnectError("refused")) == (
+            "Connection error: refused"
+        )
 
 
 class TestRaiseStreamError:

--- a/tests/core/test_client_hooks.py
+++ b/tests/core/test_client_hooks.py
@@ -90,6 +90,26 @@ class TestTransportConveniences:
         # trust_env=False ignores env proxies entirely
         assert resolve_proxy(cfg(trust_env=False)) is None
 
+    @respx.mock
+    def test_connection_error_names_configured_proxy(self):
+        # A connect failure through a configured proxy names the proxy hop
+        # (credentials stripped) so the message is not a bare "Connection refused".
+        respx.post(LUCENE).mock(side_effect=httpx.ConnectError("[Errno 111] refused"))
+        with Vulners(KEY, max_retries=0, proxy="http://user:secret@proxy.local:3128") as client:
+            with pytest.raises(APIConnectionError) as excinfo:
+                client.search.query("ssh")
+        message = str(excinfo.value)
+        assert "(proxy http://proxy.local:3128)" in message
+        assert "secret" not in message
+
+    @respx.mock
+    def test_connection_error_plain_without_proxy(self):
+        respx.post(LUCENE).mock(side_effect=httpx.ConnectError("[Errno 111] refused"))
+        with Vulners(KEY, max_retries=0) as client:
+            with pytest.raises(APIConnectionError) as excinfo:
+                client.search.query("ssh")
+        assert "proxy" not in str(excinfo.value)
+
     def test_sync_verify_false_disables_tls_verification(self):
         with Vulners(KEY, verify=False) as client:
             inner = client._api._client._transport._transport

--- a/tests/core/test_retry.py
+++ b/tests/core/test_retry.py
@@ -10,7 +10,7 @@ import respx
 import vulners._transport_client_async as _tca
 import vulners._transport_client_sync as _tcs
 from vulners._base_client import RequestSpec
-from vulners._client import Vulners
+from vulners._client import AsyncVulners, Vulners
 from vulners._exceptions import APIConnectionError, APITimeoutError, InternalServerError
 
 KEY = "SYNTHETIC-TEST-KEY"
@@ -110,3 +110,42 @@ class TestTimeoutRetry:
                 client._api.request(spec, body={})
         # connection never delivered the request -> safe to retry
         assert route.call_count == 3
+
+
+class TestProxyErrorRetry:
+    @respx.mock
+    def test_407_proxy_auth_not_retried(self):
+        # A proxy that rejects the CONNECT with 407 will reject it identically on
+        # retry, so the failure is terminal: one attempt, no retries. The raised
+        # error names the proxy (credentials stripped) but keeps its type.
+        route = respx.post(SEARCH_URL).mock(
+            side_effect=httpx.ProxyError("407 Proxy Authentication Required")
+        )
+        with Vulners(KEY, proxy="http://user:secret@proxy.local:3128") as client:
+            with pytest.raises(APIConnectionError) as excinfo:
+                client.search.query("ssh")
+        assert route.call_count == 1
+        message = str(excinfo.value)
+        assert "407" in message
+        assert "(proxy http://proxy.local:3128)" in message
+        assert "secret" not in message
+
+    @respx.mock
+    def test_non_407_proxy_error_still_retried(self):
+        # Only 407 is terminal; other proxy errors stay retryable (idempotent GET).
+        route = respx.post(SEARCH_URL).mock(side_effect=httpx.ProxyError("502 Bad Gateway"))
+        with Vulners(KEY, proxy="http://proxy.local:3128") as client:
+            with pytest.raises(APIConnectionError):
+                client.search.query("ssh")
+        assert route.call_count == 3
+
+    @respx.mock
+    async def test_407_proxy_auth_not_retried_async(self):
+        route = respx.post(SEARCH_URL).mock(
+            side_effect=httpx.ProxyError("407 Proxy Authentication Required")
+        )
+        async with AsyncVulners(KEY, proxy="http://proxy.local:3128") as client:
+            with pytest.raises(APIConnectionError) as excinfo:
+                await client.search.query("ssh")
+        assert route.call_count == 1
+        assert "(proxy http://proxy.local:3128)" in str(excinfo.value)


### PR DESCRIPTION
## Problem

When a request goes through a proxy, two failure modes were indistinguishable from a plain
API outage, and one class of failure was retried needlessly:

- A connection failure on the proxy hop (proxy down, wrong port, DNS) raised the same bare
  `Connection error: ...` as a failure to reach the API directly — nothing in the message
  said a proxy was even involved, let alone which one.
- A `407 Proxy Authentication Required` from the proxy's `CONNECT` was treated like any other
  transport error and retried up to `max_retries` times, even though the same credentials
  will be rejected identically on every attempt.

(A third, related issue — environment proxies being silently ignored because `httpx` skips
`trust_env`-based proxy resolution once an explicit transport is mounted — was already fixed
on `v4.0` in `3ffd558` and is not part of this PR; it's included here only as context for why
`_proxy` is resolved once up front in the transport constructor.)

## Fix

- **`src/vulners/_base_client.py`**
  - `_redact_proxy(proxy)`: renders a proxy as `scheme://host[:port]`, stripping any userinfo
    (proxy password) — safe to put in an error message or log.
  - `_is_proxy_auth_error(exc)`: `True` for an `httpx.ProxyError` whose message starts with
    `407`. httpx exposes the CONNECT status only in the exception text (no numeric attribute),
    so it's matched on that.
  - `BaseClient._proxy` slot + `_connection_error_message(exc)`: builds
    `Connection error: {exc}`, appending `(proxy {redacted})` when a proxy is configured.
  - `_retryable_exc()`: returns `False` for `_is_proxy_auth_error(exc)` before the existing
    idempotency checks, so a 407 is raised on the first attempt regardless of HTTP verb.
- **`src/vulners/_transport_client_async.py`** (source of truth; sync is unasyncd from this)
  - Stores the resolved proxy on `self._proxy` instead of passing it inline to
    `httpx.AsyncHTTPTransport(proxy=...)`, so it's available for error messages.
  - Both `except httpx.TransportError` handlers now build the error via
    `self._connection_error_message(exc)` instead of a bare f-string.
- **`src/vulners/_transport_client_sync.py`** — regenerated via `unasyncd`, not hand-edited.
- **`tests/core/test_base_client_units.py`** — unit coverage for `_redact_proxy` (with/without
  port, `str` vs `httpx.Proxy`) and `_is_proxy_auth_error` (407 / non-407 / non-proxy
  exceptions).
- **`tests/core/test_retry.py`** — respx-mocked: 407 stops after one attempt (sync + async,
  `call_count == 1`), a non-407 `ProxyError` still retries (`call_count == 3`), and the raised
  message names the proxy with credentials stripped.
- **`tests/core/test_client_hooks.py`** — respx-mocked: a connect failure through a configured
  proxy names it (credentials redacted); without a proxy the message is unchanged.
- **`documentation/how-to/proxy-timeout-retries.md`** — new "When the proxy is the problem"
  section documenting both behaviors.

## Testing

Gates (all green): lint (`ruff check`), format (`ruff format --check`), types (`mypy`),
`unasyncd --check` (sync client matches the async source), full unit suite with 100% coverage,
and the BC oracle (public API surface unchanged).

End-to-end, through a real local `CONNECT` proxy (custom `authproxy.py`, access-logged), run
against both sync and async clients:

- `auth_ok` — explicit `proxy=` with correct Basic auth → tunnel established, request succeeds.
- `explicit_ok` — explicit `proxy=`, no auth, HTTP/2 → succeeds.
- `env_default` (env + NO_PROXY bypass) — proxy picked up from `HTTPS_PROXY`/`trust_env`,
  and bypassed when the target host matches `NO_PROXY` → both succeed.
- `auth_bad_407` — wrong Basic credentials → proxy returns 407, exactly one `CONNECT` attempt
  in the access log, `APIConnectionError: Connection error: 407 Proxy Authentication Required
  (proxy http://127.0.0.1:8890)`.
- `dead_proxy_explicit` / `env_dead` — proxy port not listening → `APIConnectionError:
  Connection error: [Errno 111] Connection refused (proxy http://127.0.0.1:9999)`, proxy named
  in both the explicit-`proxy=` and env-resolved cases.

## Notes

No behavior change from this PR alone (env-proxy honoring landed separately in `3ffd558`).
On top of that: an `APIConnectionError` raised while a proxy is configured now names the proxy
(credentials always redacted), and `407 Proxy Authentication Required` is raised immediately
instead of being retried up to `max_retries` times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
