### PR TITLE
fix: map errorCode 158 (scope violation) to PermissionDeniedError

### DIFF
--- a/src/vulners/_exceptions.py
+++ b/src/vulners/_exceptions.py
@@ -313,6 +313,11 @@ ERROR_CODE_MAP: dict[int, type[APIStatusError]] = {
     103: BadRequestError,
     # "Wrong/invalid parameter value".
     104: BadRequestError,
+    # "Api key scope violation" — the key is valid but not licensed for this
+    # endpoint; a scope violation is a permission denial. The server returns this
+    # in a v3 envelope that can arrive with HTTP 200, so mapping the errorCode
+    # (rather than only the status) is what makes it a PermissionDeniedError.
+    158: PermissionDeniedError,
 }
 
 

--- a/src/vulners/_resources/_async/subscriptions_v4.py
+++ b/src/vulners/_resources/_async/subscriptions_v4.py
@@ -2,9 +2,11 @@
 
 The v4 subscription API with JSON delivery, reachable as ``client.subscriptions``
 (``client.subscriptions_v4`` remains a temporary alias of the same resource).
-``create`` sends the full subscription definition; ``update`` is a partial
-update — only the fields you pass are sent, everything else keeps its stored
-value.
+``create`` sends the full subscription definition. ``update`` is **not** a
+partial update: while the client omits any argument you leave unset, the server
+requires ``query``, ``delivery`` and ``send_empty_result`` on every call and
+rejects a request missing any of them with HTTP 400 — so pass those three (plus
+the subscription ``id``) on every update.
 """
 
 from __future__ import annotations
@@ -157,22 +159,27 @@ class AsyncSubscriptionsV4(_base.AsyncBaseResource):
         send_empty_result: bool | NotGiven = not_given,
         timeout: float | httpx.Timeout | NotGiven = not_given,
     ) -> Any:
-        """Update a subscription, sending only the fields you pass.
+        """Update a subscription.
 
-        This is a partial update: an argument you omit is left out of the
-        request entirely, so the stored value is kept. Pass a field explicitly
-        to change it.
+        This is **not** a partial update. The client omits any argument you
+        leave unset, but the server requires ``query``, ``delivery`` and
+        ``send_empty_result`` on every call and returns HTTP 400 if any of them
+        is missing — so pass all three on every update, even when you only mean
+        to change one other field.
 
         Args:
             id: The subscription to update.
             name: New subscription name.
-            query: New query definition (discriminated by ``type``).
+            query: New query definition (discriminated by ``type``). Required on
+                every call.
             delivery: New delivery definition (discriminated by ``type``).
+                Required on every call.
             license_id: License to bill against (``None`` clears it).
             bulletin_fields: Bulletin fields to include in results.
             is_active: Enable or disable the subscription.
             timestamp_source: Which timestamp drives incremental delivery.
             send_empty_result: Deliver even when there are no new results.
+                Required on every call.
         """
         body: dict[str, Any] = {"id": id}
         self._set(body, "name", name)

--- a/src/vulners/_resources/_sync/subscriptions_v4.py
+++ b/src/vulners/_resources/_sync/subscriptions_v4.py
@@ -4,9 +4,11 @@
 
 The v4 subscription API with JSON delivery, reachable as ``client.subscriptions``
 (``client.subscriptions_v4`` remains a temporary alias of the same resource).
-``create`` sends the full subscription definition; ``update`` is a partial
-update — only the fields you pass are sent, everything else keeps its stored
-value.
+``create`` sends the full subscription definition. ``update`` is **not** a
+partial update: while the client omits any argument you leave unset, the server
+requires ``query``, ``delivery`` and ``send_empty_result`` on every call and
+rejects a request missing any of them with HTTP 400 — so pass those three (plus
+the subscription ``id``) on every update.
 """
 
 from __future__ import annotations
@@ -159,22 +161,27 @@ class SubscriptionsV4(_base.BaseResource):
         send_empty_result: bool | NotGiven = not_given,
         timeout: float | httpx.Timeout | NotGiven = not_given,
     ) -> Any:
-        """Update a subscription, sending only the fields you pass.
+        """Update a subscription.
 
-        This is a partial update: an argument you omit is left out of the
-        request entirely, so the stored value is kept. Pass a field explicitly
-        to change it.
+        This is **not** a partial update. The client omits any argument you
+        leave unset, but the server requires ``query``, ``delivery`` and
+        ``send_empty_result`` on every call and returns HTTP 400 if any of them
+        is missing — so pass all three on every update, even when you only mean
+        to change one other field.
 
         Args:
             id: The subscription to update.
             name: New subscription name.
-            query: New query definition (discriminated by ``type``).
+            query: New query definition (discriminated by ``type``). Required on
+                every call.
             delivery: New delivery definition (discriminated by ``type``).
+                Required on every call.
             license_id: License to bill against (``None`` clears it).
             bulletin_fields: Bulletin fields to include in results.
             is_active: Enable or disable the subscription.
             timestamp_source: Which timestamp drives incremental delivery.
             send_empty_result: Deliver even when there are no new results.
+                Required on every call.
         """
         body: dict[str, Any] = {"id": id}
         self._set(body, "name", name)

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import httpx
 import pytest
+import respx
 
+from vulners._client import Vulners
 from vulners._exceptions import (
     APIStatusError,
     AuthenticationError,
@@ -40,6 +42,30 @@ class TestExtractError:
         assert "bad param" in info.message
         # errorCode-first mapping wins over the (200) status fallback.
         assert isinstance(_make_error(info), BadRequestError)
+
+    def test_scope_violation_158_in_http_200_is_permission_denied(self):
+        # "Api key scope violation" arrives in a v3 envelope with HTTP 200; the
+        # errorCode-first mapping must classify it as a permission denial, not a
+        # generic APIStatusError from the (200) status fallback.
+        body = {
+            "result": "error",
+            "data": {"error": "Api key scope violation", "errorCode": 158},
+        }
+        info = _extract_error(200, _headers(), body)
+        assert info is not None
+        assert info.status_code == 200
+        assert info.error_code == 158
+        assert isinstance(_make_error(info), PermissionDeniedError)
+
+    def test_scope_violation_158_on_403_is_permission_denied(self):
+        # Same code delivered on an HTTP 403 also maps to PermissionDeniedError
+        # (which is the 403 status class too, so the mapping is consistent).
+        body = {"result": "error", "data": {"error": "Api key scope violation", "errorCode": 158}}
+        info = _extract_error(403, _headers(), body)
+        assert info is not None
+        assert info.status_code == 403
+        assert info.error_code == 158
+        assert isinstance(_make_error(info), PermissionDeniedError)
 
     def test_v4_validation_400_is_bad_request_and_redacts_input(self):
         body = {
@@ -107,6 +133,57 @@ class TestExtractError:
         err = _make_error(info)
         assert isinstance(err, APIStatusError)
         assert err.status_code == 418
+
+
+_SCOPE_KEY = "SYNTHETIC-TEST-KEY"
+_SCOPE_SEARCH_URL = "https://vulners.com/api/v3/search/lucene/"
+_SCOPE_ENVELOPE = {
+    "result": "error",
+    "data": {"error": "Api key scope violation", "errorCode": 158},
+}
+
+
+class TestScopeViolationEndToEnd:
+    """errorCode 158 (scope violation) reaches the caller as PermissionDeniedError."""
+
+    @respx.mock
+    def test_http_200_error_body_raises_permission_denied(self):
+        # The server returns the scope violation in a v3 envelope with HTTP 200.
+        route = respx.post(_SCOPE_SEARCH_URL).mock(
+            return_value=httpx.Response(200, json=_SCOPE_ENVELOPE)
+        )
+        with Vulners(_SCOPE_KEY) as client:
+            with pytest.raises(PermissionDeniedError) as excinfo:
+                client.search.query("ssh")
+        # A permission error is terminal: no retries.
+        assert route.call_count == 1
+        assert excinfo.value.error_code == 158
+        assert excinfo.value.status_code == 200
+
+    @respx.mock
+    def test_http_403_error_body_raises_permission_denied(self):
+        route = respx.post(_SCOPE_SEARCH_URL).mock(
+            return_value=httpx.Response(403, json=_SCOPE_ENVELOPE)
+        )
+        with Vulners(_SCOPE_KEY) as client:
+            with pytest.raises(PermissionDeniedError) as excinfo:
+                client.search.query("ssh")
+        assert route.call_count == 1
+        assert excinfo.value.error_code == 158
+        assert excinfo.value.status_code == 403
+
+    @respx.mock
+    def test_scope_violation_still_catchable_as_legacy_vulners_api_error(self):
+        # The v3-era co-hierarchy is preserved: a PermissionDeniedError is still a
+        # VulnersApiError, so migrating handlers keep catching it (BC unchanged).
+        from vulners.base import VulnersApiError
+
+        respx.post(_SCOPE_SEARCH_URL).mock(return_value=httpx.Response(200, json=_SCOPE_ENVELOPE))
+        with Vulners(_SCOPE_KEY) as client:
+            with pytest.raises(VulnersApiError) as excinfo:
+                client.search.query("ssh")
+        assert isinstance(excinfo.value, PermissionDeniedError)
+        assert excinfo.value.error_code == 158
 
 
 class TestRetryAfter:


### PR DESCRIPTION
## Problem

The modern client (`vulners._client.Vulners`) classified an "Api key scope
violation" response (`errorCode` 158) as a generic `APIStatusError`, so
callers had no way to catch it as `PermissionDeniedError`. `ERROR_CODE_MAP`
only listed 103/104, and the server can return code 158 inside a v3 error
envelope delivered with HTTP **200**, so the HTTP-status fallback never
reached `PermissionDeniedError` either — the error was silently
unclassifiable via the modern exception hierarchy.

Additionally, the `subscriptions.update()` docstrings (module- and
method-level) claimed it performs a **partial update** — "only the fields you
pass are sent, everything else keeps its stored value." In practice the
server requires `query`, `delivery`, and `send_empty_result` on every call and
returns HTTP 400 (`Field required`) if any is missing, so the documented
behavior was wrong and would mislead a caller into dropping required fields.

## Fix

- `src/vulners/_exceptions.py` — add `158: PermissionDeniedError` to
  `ERROR_CODE_MAP`, with a comment explaining that the errorCode-first lookup
  (which runs before the HTTP-status fallback) is what makes this classify
  correctly even when the server wraps the error in an HTTP 200 body. The
  legacy `VulnersApiError` co-hierarchy is untouched — `PermissionDeniedError`
  remains a `VulnersApiError`, so existing except-clauses on the legacy type
  keep working.
- `tests/core/test_exceptions.py` — 2 unit tests on `_extract_error`/
  `_make_error` (code 158 on HTTP 403, and on an HTTP-200 v3 envelope), plus a
  new `TestScopeViolationEndToEnd` class with 3 `respx`-mocked full-client-path
  tests: HTTP-200 error body → `PermissionDeniedError`, HTTP-403 error body →
  `PermissionDeniedError`, and confirmation the error is still catchable as
  the legacy `VulnersApiError`.
- `src/vulners/_resources/_async/subscriptions_v4.py` — correct the module-
  and method-level docstrings for `update()`: it is **not** a partial update;
  the server requires `query`, `delivery`, and `send_empty_result` (plus the
  subscription `id`) on every call. Docstring-only, no behavior change.
- `src/vulners/_resources/_sync/subscriptions_v4.py` — regenerated by
  `unasyncd` from the async source above (never hand-edited).

## Testing

All project gates green on the branch:

- `ruff check` / `ruff format` — clean
- `mypy` / `basedpyright` — no issues
- `make unasync-check` — sync mirror matches generator output
- `make test` — full suite passing (baseline + 5 new tests)
- `make cov` — 100% coverage, threshold enforced
- `BC_SIGCHECK_REQUIRED=1 make bc` — backwards-compatibility oracle passing
- `make docs` (strict) — builds clean

Live-confirmed against the real API: a request that triggers an API-key scope
violation now raises `PermissionDeniedError` (errorCode 158), both for the
HTTP-200 v3-envelope delivery and the HTTP-403 delivery path; the legacy
client's error handling for the same condition is unchanged.

## Notes

A third, related finding (billing/entitlement behavior on the server side for
scope violations) is out of scope for this client-side PR and was not
touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
