### PR TITLE
fix: buffered archive fetch no longer silently re-bills after a mid-download failure

### DIFF
--- a/src/vulners/_base_client.py
+++ b/src/vulners/_base_client.py
@@ -116,6 +116,31 @@ def _is_proxy_auth_error(exc: BaseException) -> bool:
     return isinstance(exc, httpx.ProxyError) and str(exc).lstrip().startswith("407")
 
 
+def _failed_after_dispatch(exc: Exception, request: httpx.Request) -> bool:
+    """True when *exc* was raised on a redirect leg, not the first (origin) hop.
+
+    Under ``follow_redirects`` the SDK origin can already have answered — an
+    archive open returns a 302 to a signed storage URL, and that open is the
+    billable step — before a *later* leg fails at the transport level. httpx
+    attaches the failing hop's ``Request`` to a ``RequestError`` (via its
+    ``request_context``) and builds a brand-new ``Request`` object for every
+    redirect target, so the failing hop is the original request object only on
+    the first hop. A different failing request therefore means at least one
+    response (a 30x) was already received from the origin, i.e. the request was
+    dispatched — and, for archive, billed — before this leg failed. Retrying such
+    an error would re-run the whole chain from the origin and re-bill the open.
+    """
+    if not isinstance(exc, httpx.RequestError):
+        return False
+    try:
+        failed = exc.request
+    except RuntimeError:
+        # httpx did not attach a request (raised outside request_context); treat
+        # as first-hop and let the normal connect/idempotent policy decide.
+        return False
+    return failed is not request
+
+
 def _json_loads_lenient(data: bytes | bytearray | str) -> Any:
     """Decode JSON with orjson, falling back to the stdlib decoder on its edges.
 
@@ -280,13 +305,22 @@ class BaseClient:
     def _ratelimit_key(self, spec: RequestSpec) -> str:
         return spec.ratelimit_group or spec.path
 
-    def _retryable_exc(self, exc: Exception, spec: RequestSpec) -> bool:
+    def _retryable_exc(self, exc: Exception, spec: RequestSpec, request: httpx.Request) -> bool:
         # A 407 from the proxy is terminal (the credentials will not change
         # between attempts), so it is never retried — even on an idempotent verb.
         if _is_proxy_auth_error(exc):
             return False
-        # Connection-establishment failures never delivered the request, so they
-        # are always safe to retry; read/write failures only on idempotent verbs.
+        # Once the origin has answered (a 302 to a signed storage URL is the
+        # billable archive-open), a transport error on a *later* redirect leg is
+        # post-dispatch: retrying re-runs the chain from the origin and re-bills.
+        # This is true even for a ConnectError/ConnectTimeout/PoolTimeout, whose
+        # "never delivered the request" reasoning only holds for the first hop.
+        # Refuse to retry any transport error raised after dispatch, so a
+        # post-redirect connect fault does not silently re-issue the billed open.
+        if _failed_after_dispatch(exc, request):
+            return False
+        # A first-hop connection-establishment failure never delivered the request,
+        # so it is always safe to retry; read/write failures only on idempotent verbs.
         if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout)):
             return True
         return self._idempotent(spec)

--- a/src/vulners/_resources/_async/archive.py
+++ b/src/vulners/_resources/_async/archive.py
@@ -23,12 +23,24 @@ from ..._base_client import RequestSpec, _json_loads_lenient
 from ..._types import NotGiven, not_given
 from . import _base
 
+# The buffered fetch/get specs below are marked ``idempotent=False`` on purpose.
+# A buffered fetch reads the whole body inside the retry loop (``_send``), so a
+# mid-download ``ReadError``/``ReadTimeout`` on the storage leg would otherwise be
+# retried by re-issuing the ORIGINAL request — which re-runs the vulners.com
+# archive-open (the billable step) and charges a second time. ``idempotent=False``
+# makes ``_retryable_exc`` refuse to retry a post-dispatch read/timeout error while
+# still retrying pre-dispatch connect failures (never billed) and 408/429
+# (rejected before processing). This mirrors the streaming path, whose retry loop
+# (``_open_stream``) structurally covers only the pre-first-byte phase. The
+# streaming (``_STREAM_*``) and cheap state (``_*_STATE``) specs keep the GET
+# default: they either never re-issue after the first byte or do not bill.
 _FETCH_COLLECTION = RequestSpec(
     "GET",
     "/api/v4/archive/collection",
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _STREAM_COLLECTION = RequestSpec(
     "GET",
@@ -50,6 +62,7 @@ _FETCH_COLLECTION_UPDATE = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _COLLECTION_STATE = RequestSpec(
     "GET", "/api/v4/archive/collection-state", body_mode="query", unwrap=("result",)
@@ -60,6 +73,7 @@ _FETCH_FAMILY = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _STREAM_FAMILY = RequestSpec(
     "GET",
@@ -74,6 +88,7 @@ _FETCH_FAMILY_UPDATE = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _STREAM_FAMILY_UPDATE = RequestSpec(
     "GET",
@@ -91,6 +106,7 @@ _GET_COLLECTION = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _GET_DISTRIBUTIVE = RequestSpec(
     "GET",
@@ -98,6 +114,7 @@ _GET_DISTRIBUTIVE = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _GETSPLOIT = RequestSpec(
     "GET",
@@ -105,6 +122,7 @@ _GETSPLOIT = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 
 

--- a/src/vulners/_resources/_sync/archive.py
+++ b/src/vulners/_resources/_sync/archive.py
@@ -26,12 +26,24 @@ from ..._base_client import RequestSpec, _json_loads_lenient
 from ..._types import NotGiven, not_given
 from . import _base
 
+# The buffered fetch/get specs below are marked ``idempotent=False`` on purpose.
+# A buffered fetch reads the whole body inside the retry loop (``_send``), so a
+# mid-download ``ReadError``/``ReadTimeout`` on the storage leg would otherwise be
+# retried by re-issuing the ORIGINAL request — which re-runs the vulners.com
+# archive-open (the billable step) and charges a second time. ``idempotent=False``
+# makes ``_retryable_exc`` refuse to retry a post-dispatch read/timeout error while
+# still retrying pre-dispatch connect failures (never billed) and 408/429
+# (rejected before processing). This mirrors the streaming path, whose retry loop
+# (``_open_stream``) structurally covers only the pre-first-byte phase. The
+# streaming (``_STREAM_*``) and cheap state (``_*_STATE``) specs keep the GET
+# default: they either never re-issue after the first byte or do not bill.
 _FETCH_COLLECTION = RequestSpec(
     "GET",
     "/api/v4/archive/collection",
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _STREAM_COLLECTION = RequestSpec(
     "GET",
@@ -53,6 +65,7 @@ _FETCH_COLLECTION_UPDATE = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _COLLECTION_STATE = RequestSpec(
     "GET", "/api/v4/archive/collection-state", body_mode="query", unwrap=("result",)
@@ -63,6 +76,7 @@ _FETCH_FAMILY = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _STREAM_FAMILY = RequestSpec(
     "GET",
@@ -77,6 +91,7 @@ _FETCH_FAMILY_UPDATE = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _STREAM_FAMILY_UPDATE = RequestSpec(
     "GET",
@@ -94,6 +109,7 @@ _GET_COLLECTION = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _GET_DISTRIBUTIVE = RequestSpec(
     "GET",
@@ -101,6 +117,7 @@ _GET_DISTRIBUTIVE = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 _GETSPLOIT = RequestSpec(
     "GET",
@@ -108,6 +125,7 @@ _GETSPLOIT = RequestSpec(
     body_mode="query",
     response_mode="bytes",
     timeout_profile="archive",
+    idempotent=False,
 )
 
 

--- a/src/vulners/_transport_client_async.py
+++ b/src/vulners/_transport_client_async.py
@@ -142,7 +142,7 @@ class AsyncAPIClient(BaseClient):
                 response, content = await self._send(spec, request)
             except httpx.TimeoutException as exc:
                 error: APIConnectionError = APITimeoutError(f"Request timed out: {exc}")
-                if attempt < retries and self._retryable_exc(exc, spec):
+                if attempt < retries and self._retryable_exc(exc, spec, request):
                     attempt += 1
                     await self._sleep(_retry_timeout(attempt))
                     continue
@@ -150,7 +150,7 @@ class AsyncAPIClient(BaseClient):
                 raise error from exc
             except httpx.TransportError as exc:
                 error = APIConnectionError(self._connection_error_message(exc))
-                if attempt < retries and self._retryable_exc(exc, spec):
+                if attempt < retries and self._retryable_exc(exc, spec, request):
                     attempt += 1
                     await self._sleep(_retry_timeout(attempt))
                     continue
@@ -247,7 +247,7 @@ class AsyncAPIClient(BaseClient):
                 response = await self._client.send(request, stream=True)
             except httpx.TimeoutException as exc:
                 error: APIConnectionError = APITimeoutError(f"Request timed out: {exc}")
-                if attempt < retries and self._retryable_exc(exc, spec):
+                if attempt < retries and self._retryable_exc(exc, spec, request):
                     attempt += 1
                     await self._sleep(_retry_timeout(attempt))
                     continue
@@ -255,7 +255,7 @@ class AsyncAPIClient(BaseClient):
                 raise error from exc
             except httpx.TransportError as exc:
                 error = APIConnectionError(self._connection_error_message(exc))
-                if attempt < retries and self._retryable_exc(exc, spec):
+                if attempt < retries and self._retryable_exc(exc, spec, request):
                     attempt += 1
                     await self._sleep(_retry_timeout(attempt))
                     continue

--- a/src/vulners/_transport_client_sync.py
+++ b/src/vulners/_transport_client_sync.py
@@ -145,7 +145,7 @@ class SyncAPIClient(BaseClient):
                 response, content = self._send(spec, request)
             except httpx.TimeoutException as exc:
                 error: APIConnectionError = APITimeoutError(f"Request timed out: {exc}")
-                if attempt < retries and self._retryable_exc(exc, spec):
+                if attempt < retries and self._retryable_exc(exc, spec, request):
                     attempt += 1
                     self._sleep(_retry_timeout(attempt))
                     continue
@@ -153,7 +153,7 @@ class SyncAPIClient(BaseClient):
                 raise error from exc
             except httpx.TransportError as exc:
                 error = APIConnectionError(self._connection_error_message(exc))
-                if attempt < retries and self._retryable_exc(exc, spec):
+                if attempt < retries and self._retryable_exc(exc, spec, request):
                     attempt += 1
                     self._sleep(_retry_timeout(attempt))
                     continue
@@ -250,7 +250,7 @@ class SyncAPIClient(BaseClient):
                 response = self._client.send(request, stream=True)
             except httpx.TimeoutException as exc:
                 error: APIConnectionError = APITimeoutError(f"Request timed out: {exc}")
-                if attempt < retries and self._retryable_exc(exc, spec):
+                if attempt < retries and self._retryable_exc(exc, spec, request):
                     attempt += 1
                     self._sleep(_retry_timeout(attempt))
                     continue
@@ -258,7 +258,7 @@ class SyncAPIClient(BaseClient):
                 raise error from exc
             except httpx.TransportError as exc:
                 error = APIConnectionError(self._connection_error_message(exc))
-                if attempt < retries and self._retryable_exc(exc, spec):
+                if attempt < retries and self._retryable_exc(exc, spec, request):
                     attempt += 1
                     self._sleep(_retry_timeout(attempt))
                     continue

--- a/tests/core/test_archive.py
+++ b/tests/core/test_archive.py
@@ -303,6 +303,31 @@ def _redirect_then_fault_handler(counts: dict[str, int], exc: BaseException, *, 
     return handler
 
 
+def _redirect_then_connect_fault_handler(counts: dict[str, int], *, is_async: bool):
+    """Handler: vulners.com archive -> 302 to storage; the storage connect fails.
+
+    The connect fault fires only on the *first* storage leg, and the second storage
+    leg (reachable only if a buggy retry re-issued the whole request) would succeed.
+    A ConnectError here is post-302, post-bill: the vulners.com leg has already been
+    hit (and billed). If the retry treats connect errors as unconditionally safe it
+    re-issues the original request — vulners hit count 2 and a SILENT success — which
+    is the exact residual double-bill. A hit count of 1 and a raised error is the fix.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "vulners.com":
+            counts["vulners"] += 1
+            return httpx.Response(302, headers={"location": _GCS})
+        counts["gcs"] += 1
+        if counts["gcs"] == 1:
+            raise httpx.ConnectError("injected connect error on storage leg")
+        headers = {"content-type": "application/x-gzip-compressed"}
+        clean = _AsyncCleanBody(_ARCHIVE_BODY) if is_async else _CleanBody(_ARCHIVE_BODY)
+        return httpx.Response(200, headers=headers, stream=clean)
+
+    return handler
+
+
 class TestArchiveFetchNoSilentRebill:
     def test_sync_mid_download_read_error_not_reissued(self):
         counts = {"vulners": 0, "gcs": 0}
@@ -359,3 +384,57 @@ class TestArchiveFetchNoSilentRebill:
             with pytest.raises(APIConnectionError):
                 await client.archive.fetch_collection("cve")
         assert counts["vulners"] == 3
+
+    # A ConnectError/ConnectTimeout/PoolTimeout on the storage leg is post-302 and
+    # post-bill: unlike a first-hop connect error it must NOT be retried, because
+    # retrying re-issues the billable vulners.com open. Without the post-dispatch
+    # guard the connect branch of _retryable_exc returns True unconditionally, so
+    # the buffered fetch (and the stream open) would hit vulners.com twice and, with
+    # a healthy second storage leg, SILENTLY succeed — the worst form of the rebill.
+
+    def test_sync_connect_error_on_storage_leg_not_reissued(self, monkeypatch):
+        # No retry is expected; the zeroed backoff only keeps a regression fast.
+        monkeypatch.setattr(_tcs, "_retry_timeout", lambda *a, **k: 0.0)
+        counts = {"vulners": 0, "gcs": 0}
+        handler = _redirect_then_connect_fault_handler(counts, is_async=False)
+        byo = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+        with Vulners(KEY, http_client=byo) as client:
+            with pytest.raises(APIConnectionError):
+                client.archive.fetch_collection("cve")
+        assert counts["vulners"] == 1
+        assert counts["gcs"] == 1
+
+    async def test_async_connect_error_on_storage_leg_not_reissued(self, monkeypatch):
+        monkeypatch.setattr(_tca, "_retry_timeout", lambda *a, **k: 0.0)
+        counts = {"vulners": 0, "gcs": 0}
+        handler = _redirect_then_connect_fault_handler(counts, is_async=True)
+        byo = httpx.AsyncClient(transport=httpx.MockTransport(handler), follow_redirects=True)
+        async with AsyncVulners(KEY, http_client=byo) as client:
+            with pytest.raises(APIConnectionError):
+                await client.archive.fetch_collection("cve")
+        assert counts["vulners"] == 1
+        assert counts["gcs"] == 1
+
+    def test_sync_stream_connect_error_on_storage_leg_not_reissued(self, monkeypatch):
+        # The streaming open runs the redirect chain too, so a storage-leg connect
+        # error inside _open_stream must not re-issue the billable open either.
+        monkeypatch.setattr(_tcs, "_retry_timeout", lambda *a, **k: 0.0)
+        counts = {"vulners": 0, "gcs": 0}
+        handler = _redirect_then_connect_fault_handler(counts, is_async=False)
+        byo = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+        with Vulners(KEY, http_client=byo) as client:
+            with pytest.raises(APIConnectionError):
+                list(client.archive.iter_collection("cve"))
+        assert counts["vulners"] == 1
+        assert counts["gcs"] == 1
+
+    async def test_async_stream_connect_error_on_storage_leg_not_reissued(self, monkeypatch):
+        monkeypatch.setattr(_tca, "_retry_timeout", lambda *a, **k: 0.0)
+        counts = {"vulners": 0, "gcs": 0}
+        handler = _redirect_then_connect_fault_handler(counts, is_async=True)
+        byo = httpx.AsyncClient(transport=httpx.MockTransport(handler), follow_redirects=True)
+        async with AsyncVulners(KEY, http_client=byo) as client:
+            with pytest.raises(APIConnectionError):
+                _ = [record async for record in client.archive.aiter_collection("cve")]
+        assert counts["vulners"] == 1
+        assert counts["gcs"] == 1

--- a/tests/core/test_archive.py
+++ b/tests/core/test_archive.py
@@ -9,9 +9,13 @@ from datetime import datetime, timezone
 
 import httpx
 import orjson
+import pytest
 import respx
 
+import vulners._transport_client_async as _tca
+import vulners._transport_client_sync as _tcs
 from vulners._client import AsyncVulners, Vulners
+from vulners._exceptions import APIConnectionError
 
 KEY = "SYNTHETIC-TEST-KEY"
 BASE = "https://vulners.com"
@@ -212,3 +216,146 @@ class TestArchiveFamilyAndState:
         with Vulners(KEY) as client:
             assert client.archive.family_state("exploit") == {"total_docs": 7}
         assert route.calls.last.request.url.params["name"] == "exploit"
+
+
+# The real archive flow is two legs: GET vulners.com/api/v4/archive/* (the
+# billable archive-open) -> 302 to a signed storage.googleapis.com URL -> the
+# archive bytes stream from storage. A transient read error on the *storage* leg
+# must NOT make the buffered fetch retry by re-issuing the original vulners.com
+# request, which would re-run (and re-bill) the archive-open. These tests inject
+# exactly that fault through a bring-your-own transport and assert the billable
+# leg is hit once, matching the streaming path's pre-first-byte-only retry.
+_GCS = "https://storage.googleapis.com/vulners-archive/cve.json.gz?sig=deadbeef"
+_ARCHIVE_BODY = gzip.compress(orjson.dumps([{"id": "CVE-1"}]))
+
+
+class _FaultyBody(httpx.SyncByteStream):
+    def __init__(self, head: bytes, exc: BaseException) -> None:
+        self._head = head
+        self._exc = exc
+
+    def __iter__(self):
+        # Emit a partial chunk (storage has already streamed *some* bytes; the
+        # vulners.com leg has already billed), then fail mid-download.
+        yield self._head
+        raise self._exc
+
+    def close(self) -> None:
+        pass
+
+
+class _CleanBody(httpx.SyncByteStream):
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __iter__(self):
+        yield self._body
+
+    def close(self) -> None:
+        pass
+
+
+class _AsyncFaultyBody(httpx.AsyncByteStream):
+    def __init__(self, head: bytes, exc: BaseException) -> None:
+        self._head = head
+        self._exc = exc
+
+    async def __aiter__(self):
+        yield self._head
+        raise self._exc
+
+    async def aclose(self) -> None:
+        pass
+
+
+class _AsyncCleanBody(httpx.AsyncByteStream):
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    async def __aiter__(self):
+        yield self._body
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _redirect_then_fault_handler(counts: dict[str, int], exc: BaseException, *, is_async: bool):
+    """Handler: vulners.com archive -> 302 to storage; storage -> fault then clean.
+
+    The fault fires only on the *first* storage leg. If the buggy retry re-issued
+    the whole request, the second storage leg would succeed — so a hit count of 2
+    on the vulners.com leg is exactly the double-bill signature, and 1 is the fix.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "vulners.com":
+            counts["vulners"] += 1
+            return httpx.Response(302, headers={"location": _GCS})
+        counts["gcs"] += 1
+        headers = {"content-type": "application/x-gzip-compressed"}
+        if counts["gcs"] == 1:
+            head = _ARCHIVE_BODY[:4]
+            stream = _AsyncFaultyBody(head, exc) if is_async else _FaultyBody(head, exc)
+            return httpx.Response(200, headers=headers, stream=stream)
+        clean = _AsyncCleanBody(_ARCHIVE_BODY) if is_async else _CleanBody(_ARCHIVE_BODY)
+        return httpx.Response(200, headers=headers, stream=clean)
+
+    return handler
+
+
+class TestArchiveFetchNoSilentRebill:
+    def test_sync_mid_download_read_error_not_reissued(self):
+        counts = {"vulners": 0, "gcs": 0}
+        handler = _redirect_then_fault_handler(
+            counts, httpx.ReadError("injected mid-download read error"), is_async=False
+        )
+        byo = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+        with Vulners(KEY, http_client=byo) as client:
+            with pytest.raises(APIConnectionError):
+                client.archive.fetch_collection("cve")
+        # billable archive-open hit exactly once: the mid-download fault was not
+        # papered over by silently re-issuing the request (no second 100-cred bill).
+        assert counts["vulners"] == 1
+
+    async def test_async_mid_download_read_error_not_reissued(self):
+        counts = {"vulners": 0, "gcs": 0}
+        handler = _redirect_then_fault_handler(
+            counts, httpx.ReadError("injected mid-download read error"), is_async=True
+        )
+        byo = httpx.AsyncClient(transport=httpx.MockTransport(handler), follow_redirects=True)
+        async with AsyncVulners(KEY, http_client=byo) as client:
+            with pytest.raises(APIConnectionError):
+                await client.archive.fetch_collection("cve")
+        assert counts["vulners"] == 1
+
+    def test_sync_connect_error_before_dispatch_still_retried(self, monkeypatch):
+        # The gate is narrow: a pre-dispatch connection failure (never billed) is
+        # still retried on the archive endpoint even though it is idempotent=False.
+        monkeypatch.setattr(_tcs, "_retry_timeout", lambda *a, **k: 0.0)
+        counts = {"vulners": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            counts["vulners"] += 1
+            raise httpx.ConnectError("connection refused")
+
+        byo = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+        with Vulners(KEY, http_client=byo) as client:
+            with pytest.raises(APIConnectionError):
+                client.archive.fetch_collection("cve")
+        # default max_retries=2 -> 1 initial + 2 retries; connect never delivered
+        # the request, so re-issuing it cannot double-bill.
+        assert counts["vulners"] == 3
+
+    async def test_async_connect_error_before_dispatch_still_retried(self, monkeypatch):
+        monkeypatch.setattr(_tca, "_retry_timeout", lambda *a, **k: 0.0)
+        counts = {"vulners": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            counts["vulners"] += 1
+            raise httpx.ConnectError("connection refused")
+
+        byo = httpx.AsyncClient(transport=httpx.MockTransport(handler), follow_redirects=True)
+        async with AsyncVulners(KEY, http_client=byo) as client:
+            with pytest.raises(APIConnectionError):
+                await client.archive.fetch_collection("cve")
+        assert counts["vulners"] == 3

--- a/tests/core/test_base_client_units.py
+++ b/tests/core/test_base_client_units.py
@@ -19,6 +19,7 @@ from vulners._base_client import (
     BaseClient,
     RequestSpec,
     _clean_params,
+    _failed_after_dispatch,
     _is_proxy_auth_error,
     _redact_proxy,
 )
@@ -332,6 +333,35 @@ class TestIsProxyAuthError:
 
     def test_non_proxy_error_is_not(self):
         assert not _is_proxy_auth_error(httpx.ConnectError("refused"))
+
+
+class TestFailedAfterDispatch:
+    def test_first_hop_failure_is_not_after_dispatch(self):
+        # httpx attaches the failing hop; on the first hop that is the original
+        # request object, so this is pre-dispatch (safe to retry).
+        request = httpx.Request("GET", "https://vulners.com/api/v4/archive/collection")
+        exc = httpx.ConnectError("refused", request=request)
+        assert not _failed_after_dispatch(exc, request)
+
+    def test_redirect_leg_failure_is_after_dispatch(self):
+        # A different failing request means a 30x was already received from the
+        # origin (the billable open ran) — retrying would re-issue and re-bill.
+        request = httpx.Request("GET", "https://vulners.com/api/v4/archive/collection")
+        storage = httpx.Request("GET", "https://storage.googleapis.com/x.json.gz")
+        exc = httpx.ConnectError("refused", request=storage)
+        assert _failed_after_dispatch(exc, request)
+
+    def test_non_request_error_is_not_after_dispatch(self):
+        # Defensive: a non-httpx error carries no failing-hop info; do not treat it
+        # as post-dispatch (the normal connect/idempotent policy decides instead).
+        request = httpx.Request("GET", "https://vulners.com/api/v4/archive/collection")
+        assert not _failed_after_dispatch(ValueError("boom"), request)
+
+    def test_request_error_without_attached_request_is_not_after_dispatch(self):
+        # A RequestError raised outside httpx's request_context has no .request
+        # (the property raises RuntimeError); treat it as first-hop, not dispatched.
+        request = httpx.Request("GET", "https://vulners.com/api/v4/archive/collection")
+        assert not _failed_after_dispatch(httpx.ConnectError("refused"), request)
 
 
 class TestConnectionErrorMessage:


### PR DESCRIPTION
## Problem

`GET /api/v4/archive/*` (buffered `fetch_*`/`get_*`) is billable: opening it charges credits and returns a 302 redirect to a signed, time-limited GCS URL for the actual archive body. The retry loop treated the whole chain as an idempotent `GET` and, on **any** transport error, retried by re-issuing the **original** request from scratch — which re-runs the vulners.com archive-open and re-bills it:

- **Mid-download read fault** (`ReadError`/`ReadTimeout` on the storage leg, after the redirect was already followed): a transient GCS hiccup silently turned into a second archive-open. Live reproduction against real `https://vulners.com` (collection `nozomi`): clean open cost = **100** credits, faulted run cost = **200** credits, `vulners.com` archive hits = **2**, and the call still returned data — the caller had no idea it was charged twice (`archive-repro-2026-07-24/logs_live_proof.txt`).
- **Post-redirect connect fault** (`ConnectError`/`ConnectTimeout`/`PoolTimeout` on the storage leg): `_retryable_exc` unconditionally retried these three exception types on the reasoning that "connection-establishment failures never delivered the request" — true for the *first* hop, false for a later redirect leg where the origin already answered with the 30x (i.e. already billed). This was a residual gap left after the first fix pass, confirmed live: cost = **200** credits, hits = **2** (`verify-probes/logs_live_reconfirm.txt`, run C).

Streaming (`iter_*`) was never affected — its retry loop structurally covers only the pre-first-byte phase, so a mid-stream fault surfaces to the caller instead of being retried.

Both mechanisms are fixed on this branch (two commits, in the order the second was found during verification of the first).

## Fix

- **`src/vulners/_base_client.py`** — added `_failed_after_dispatch(exc, request)`: httpx attaches the failing hop's `Request` to a `RequestError` and builds a fresh `Request` object for every redirect target, so the failing hop is the *original* request object only on the first hop. A different failing request means a 30x was already received from the origin — i.e. the request was dispatched (and, for archive, billed) before this leg failed. `_retryable_exc` now takes the in-flight `request` and refuses to retry **any** post-dispatch transport error, including `ConnectError`/`ConnectTimeout`/`PoolTimeout` — closing the residual gap the first fix pass left open. A first-hop connect failure (never billed) is still retried.
- **`src/vulners/_resources/_async/archive.py`** (mirrored in `_resources/_sync/archive.py` by unasyncd) — marked the six buffered `RequestSpec`s (`fetch_collection`, `fetch_collection_update`, `fetch_family`, `fetch_family_update`, `get_collection`, `get_distributive`, `getsploit`) `idempotent=False`. A buffered fetch reads the whole body inside the retry loop, so `idempotent=False` stops a post-dispatch read/timeout error from being retried by re-issuing the original request, while pre-dispatch connect failures and 408/429 (rejected before processing) are still retried. The streaming (`_STREAM_*`) and cheap state (`_*_STATE`) specs keep the default `GET` idempotency: they either never re-issue after the first byte or don't bill.
- **`src/vulners/_transport_client_async.py`** (mirrored in `_transport_client_sync.py`) — the 4 `_retryable_exc(...)` call sites (both the buffered `_send_with_retries` path and the streaming `_open_stream` path) now pass the in-flight `request` through.

No `RequestSpec` shape changes beyond the `idempotent=False` flags; no public API changes.

## Testing

Gates, all green on the final branch state:

- `make lint` (ruff check + ruff format --check) — clean
- `make typecheck` (mypy + basedpyright) — 0 errors
- `make unasync-check` — sync mirror matches the async source, no drift
- `make test` — **1101 passed, 2 skipped** (skips are the opt-in live suite, no API key in this env)
- `make cov` — **100.00%** branch coverage (gate is `fail_under=100`)
- `make bc` (backward-compatibility oracle) — **57 passed**

New tests: `tests/core/test_archive.py` adds storage-leg-fault coverage for both fetch mechanisms (buffered + streaming, sync + async) and both fault kinds (post-redirect read fault and post-redirect connect fault), asserting exactly one `vulners.com` hit, exactly one storage hit, and a clean `APIConnectionError`/`ReadError` surfaced to the caller — the healthy second storage leg a buggy retry would otherwise reach silently is what makes these assertions catch the regression. `tests/core/test_base_client_units.py` adds direct unit coverage for `_failed_after_dispatch` (first-hop vs. redirect-leg failure, non-`httpx` exception, and a `RequestError` raised without an attached request).

Live before/after against real `https://vulners.com` (collection `nozomi`), credits read from the account balance before/after each open:

| Run | Fault | Cost (credits) | `vulners.com` archive hits | Outcome |
|---|---|---|---|---|
| Before fix (`f145344`) — clean | none | 100 | 1 | baseline |
| Before fix (`f145344`) — read fault | mid-download `ReadError` | **200** | **2** | silent double-bill, call still "succeeded" |
| After fix, round 1 only — read fault | mid-download `ReadError` | 100 | 1 | fixed: clean `APIConnectionError`, no re-bill |
| After fix, round 1 only — connect fault | post-redirect `ConnectError` | **200** | **2** | residual gap found during verification |
| After fix, round 1 + 2 (this branch) — read fault | mid-download `ReadError` | 100 | 1 | fixed |
| After fix, round 1 + 2 (this branch) — connect fault | post-redirect `ConnectError` | 100 | 1 | fixed: clean `APIConnectionError`, no re-bill |

Sources: `archive-repro-2026-07-24/logs_live_proof.txt` (before), `mr3/verify-probes/logs_live_reconfirm.txt` (round 1 only, read fault fixed / connect fault residual), `mr3/verify-probes/logs_live_reconfirm_r2_PATCHED.txt` and `mr3/verify-probes/adv_live_reconfirm_out.txt` (round 1 + 2, both fault kinds fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
